### PR TITLE
fix: useShallow를 이용하여 무한 리렌더링 오류 수정

### DIFF
--- a/src/components/common/header/index.tsx
+++ b/src/components/common/header/index.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
 import { BellDot, LogIn, Menu, UserRound } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
 
 import AlarmBox from '@/components/notice/alarmBox';
 import useScreenWidth from '@/hooks/useScreenWidth';
@@ -17,7 +18,7 @@ const Header = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const pathname = usePathname();
 
-  const user = useUserStore(state => state.user);
+  const user = useUserStore(useShallow(state => state.user));
 
   const { isInit, isMobile } = useScreenWidth();
 

--- a/src/components/common/sidebar/index.tsx
+++ b/src/components/common/sidebar/index.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/navigation';
 import clsx from 'clsx';
 import { FocusTrap } from 'focus-trap-react';
 import { X } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
 
 import useOutsideClick from '@/hooks/useOutsideClick';
 import useUserActions from '@/hooks/useUserActions';
@@ -14,7 +15,7 @@ import SIDEBAR_MENUS from './constants';
 
 const Sidebar = ({ isOpen, close }: SidebarProps) => {
   const { logout } = useUserActions();
-  const { user } = useUserStore.getState();
+  const user = useUserStore(useShallow(state => state.user));
 
   const router = useRouter();
 

--- a/src/components/myPage/profile/ProfileFormContainer.tsx
+++ b/src/components/myPage/profile/ProfileFormContainer.tsx
@@ -1,6 +1,7 @@
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { usePathname } from 'next/navigation';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useShallow } from 'zustand/react/shallow';
 
 import useUserActions from '@/hooks/useUserActions';
 import useUserStore from '@/stores/userStore';
@@ -18,7 +19,7 @@ const ProfileFormContainer = () => {
   const pathname = usePathname();
   const isEditMode = pathname === '/mypage';
 
-  const user = useUserStore(state => state.user);
+  const user = useUserStore(useShallow(state => state.user));
   const { editProfile, deleteUser } = useUserActions();
 
   const formSchema = isEditMode ? profileFormSchema : signUpFormSchema;

--- a/src/hooks/useUserActions.tsx
+++ b/src/hooks/useUserActions.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import { useShallow } from 'zustand/react/shallow';
 
 import useUserStore, { EXPIRATION_TIME, UserDataType } from '@/stores/userStore';
 import {
@@ -17,12 +18,14 @@ import { ERROR_MESSAGES, INFO_MESSAGES } from './constants';
 import { API } from '@/api/constants';
 
 const useUserActions = () => {
-  const { setUser, resetUser, setAccessToken, setRefreshToken } = useUserStore(state => ({
-    setUser: state.setUser,
-    resetUser: state.resetUser,
-    setAccessToken: state.setAccessToken,
-    setRefreshToken: state.setRefreshToken,
-  }));
+  const { setUser, resetUser, setAccessToken, setRefreshToken } = useUserStore(
+    useShallow(state => ({
+      setUser: state.setUser,
+      resetUser: state.resetUser,
+      setAccessToken: state.setAccessToken,
+      setRefreshToken: state.setRefreshToken,
+    })),
+  );
   const router = useRouter();
 
   const handleError = useCallback(


### PR DESCRIPTION
```ts
const { setUser, resetUser, setAccessToken, setRefreshToken } = useUserStore(state => ({
  setUser: state.setUser,
  resetUser: state.resetUser,
  setAccessToken: state.setAccessToken,
  setRefreshToken: state.setRefreshToken,
}));
```

위와 같이 작성 시,
useStore()가 항상 새로운 객체를 반환 →
React가 새로운 상태로 인식 →
Zustand 스토어가 변경된 것으로 간주 → 리렌더링 발생
으로 인해 무한 리렌더링 오류가 발생하여, 아래와 같이 변경하였습니다.

```ts
const { setUser, resetUser, setAccessToken, setRefreshToken } = useUserStore(
  useShallow(state => ({
    setUser: state.setUser,
    resetUser: state.resetUser,
    setAccessToken: state.setAccessToken,
    setRefreshToken: state.setRefreshToken,
  })),
);
```