### PR TITLE
feat: 액세스 토큰 존재 여부에 따라 재발급 로직 실행하는 provider 추가

### DIFF
--- a/src/providers/TokenRefreshProvider.tsx
+++ b/src/providers/TokenRefreshProvider.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+
+import useUserStore from '@/stores/userStore';
+import { getAccessToken, getRefreshToken, reissueAccessToken } from '@/utils/auth';
+
+import ProviderProps from './types';
+
+const TokenRefreshProvider = ({ children }: ProviderProps) => {
+  const user = useUserStore(useShallow(state => state.user));
+
+  useEffect(() => {
+    const refreshToken = getRefreshToken();
+    const accessToken = getAccessToken();
+
+    const refresh = async () => {
+      if (user && refreshToken && !accessToken) {
+        await reissueAccessToken();
+      }
+    };
+
+    refresh();
+  }, [user]);
+
+  return <>{children}</>;
+};
+
+export default TokenRefreshProvider;

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import LayerCardProvider from './LayerCardProvider';
 import LayerPopupProvider from './LayerPopupProvider';
+import TokenRefreshProvider from './TokenRefreshProvider';
 
 import ProviderProps from './types';
 
@@ -13,9 +14,11 @@ const Providers = ({ children }: ProviderProps) => {
   return (
     <>
       <QueryClientProvider client={queryClient}>
-        <LayerPopupProvider>
-          <LayerCardProvider>{children}</LayerCardProvider>
-        </LayerPopupProvider>
+        <TokenRefreshProvider>
+          <LayerPopupProvider>
+            <LayerCardProvider>{children}</LayerCardProvider>
+          </LayerPopupProvider>
+        </TokenRefreshProvider>
       </QueryClientProvider>
     </>
   );


### PR DESCRIPTION
브라우저 종료 후, 액세스 토큰이 만료되면서 재발급 로직이 실행되지 않는 문제 확인하였습니다.

사이트 재방문 시, refresh 토큰 여부와 localStorage의 user 저장 여부에 따라 재발급 로직이 실행되는 기능을 추가하였습니다.